### PR TITLE
bump: v0.2.0

### DIFF
--- a/packages/typegpu-confetti/package.json
+++ b/packages/typegpu-confetti/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typegpu-confetti",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Customizable confetti animation component for React and React Native, running on the GPU",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump typegpu-confetti package version from 0.1.1 to 0.2.0